### PR TITLE
Docsify the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,25 @@
 **This repo contains the source of our testing course.**
 
 - For a better viewing experience, check our [**readthedocs**](https://start-testing.readthedocs.io/en/master/).
-- ~~For the best viewing experience, check out [**docsify**](https://docsify.js.org/#/).~~ (pending)
+- For the best viewing experience, check our [**docsify**](https://docsify.js.org/#/).
+
+
+
+
+
+## Docsify
+
+
+
+### Initial setup
+
+```bash
+npm i docsify-cli -g
+cd to-folder/containing/the-repo
+docsify init .
+```
+
+### Working locally
+
+`docsify serve .`
 

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -1,0 +1,6 @@
+- [Home](/)
+
+- Concepts
+  - [Oracles](/concepts/oracles.md)
+
+- Roles

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
         repo: 'https://github.com/dialex/start-testing',
         ga: 'UA-10714206-14',
 
+        loadSidebar: true,
+        subMaxLevel: 1,
+
         plugins: [
             EditOnGithubPlugin.create(
                 'https://github.com/dialex/start-testing/tree/master/'

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Testing Course</title>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+  <meta name="description" content="Description">
+  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+</head>
+<body>
+  <div id="app"></div>
+  <script>
+    window.$docsify = {
+      name: '',
+      repo: ''
+    }
+  </script>
+  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 </head>
 
 <body>
-    <div id="app"></div>
+    <div id="app">Loading the course...</div>
     <script>
     window.$docsify = {
         name: 'Start Testing',

--- a/index.html
+++ b/index.html
@@ -1,21 +1,31 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-  <meta charset="UTF-8">
-  <title>Testing Course</title>
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="Description">
-  <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+    <meta charset="UTF-8">
+    <title>Start Testing</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="description" content="Description">
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+    <script src="//unpkg.com/docsify-edit-on-github@1.0.1/index.js"></script>
 </head>
+
 <body>
-  <div id="app"></div>
-  <script>
+    <div id="app"></div>
+    <script>
     window.$docsify = {
-      name: '',
-      repo: ''
+        name: 'Start Testing',
+        repo: 'https://github.com/dialex/start-testing',
+
+        plugins: [
+            EditOnGithubPlugin.create(
+                'https://github.com/dialex/start-testing/tree/master/'
+            )
+        ]
     }
-  </script>
-  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+    </script>
+    <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
     <script src="//unpkg.com/docsify-edit-on-github@1.0.1/index.js"></script>
     <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
+    <script src="//unpkg.com/docsify/lib/plugins/emoji.min.js"></script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
     <script src="//unpkg.com/docsify-edit-on-github@1.0.1/index.js"></script>
+    <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
 </head>
 
 <body>
@@ -17,6 +18,7 @@
     window.$docsify = {
         name: 'Start Testing',
         repo: 'https://github.com/dialex/start-testing',
+        ga: 'UA-10714206-14',
 
         plugins: [
             EditOnGithubPlugin.create(

--- a/index.md
+++ b/index.md
@@ -22,14 +22,14 @@
 
 --------------
 
-##  🤔 TODO (trello syllabus) 
+## 🤔 TODO (trello syllabus)
 
 ### Concepts
 
 - [30 must knows](https://dojo.ministryoftesting.com/lessons/30-things-every-new-software-tester-should-learn)
 - https://trello.com/c/HV6ZOpus/247-concepts
 - https://trello.com/c/upYYZCF6/229-requirements
-- https://trello.com/c/ORSrD7o5/224-charters 
+- https://trello.com/c/ORSrD7o5/224-charters
 - https://trello.com/c/Q9RJZyrM/250-coverage-metrics
 - https://trello.com/c/gQ5W3qJH/241-test-types
 - https://trello.com/c/KXfdYMMf/


### PR DESCRIPTION
And ditch `readthedocs`:
- their Markdown parser is not coherent with GitHub's.
- with `docsify` we have everything hosted in a single place (GitHub).
- besides it comes with some very neat plugins and GitHub integrations.