### PR TITLE
doc: allow links directly to the checklist

### DIFF
--- a/docs/concepts/testability.md
+++ b/docs/concepts/testability.md
@@ -39,7 +39,7 @@ There are four main groups of variables that influence testability: value-relate
 
 Here's a [mnemonic](/toolbox/mnemonics.md) to remember these dimensions: usability, security and other -ilities are equally important; testability is VIP as well; thus testability dimensions are **`VIPS`** (**v**alue, **i**ntrinsic, **p**roject, **s**ubjective). Here's another: [`SOCKS`](https://www.a-sisyphean-task.com/2012/07/putting-your-testability-socks-on.html).
 
-## Checklist
+### Checklist
 
 This checklist adapted from [Ash Winter](https://testingisbelieving.blogspot.com/2017/08/the-team-test-for-testability.html) can be used for a quick **health check on your testability**. For each question answer Yes (+1) or No (+0). If your final score is below 8, you are working under unnecessary risk.
 

--- a/docs/concepts/testability.md
+++ b/docs/concepts/testability.md
@@ -39,6 +39,8 @@ There are four main groups of variables that influence testability: value-relate
 
 Here's a [mnemonic](/toolbox/mnemonics.md) to remember these dimensions: usability, security and other -ilities are equally important; testability is VIP as well; thus testability dimensions are **`VIPS`** (**v**alue, **i**ntrinsic, **p**roject, **s**ubjective). Here's another: [`SOCKS`](https://www.a-sisyphean-task.com/2012/07/putting-your-testability-socks-on.html).
 
+## Checklist
+
 This checklist adapted from [Ash Winter](https://testingisbelieving.blogspot.com/2017/08/the-team-test-for-testability.html) can be used for a quick **health check on your testability**. For each question answer Yes (+1) or No (+0). If your final score is below 8, you are working under unnecessary risk.
 
 1. Do developers react positively when a bug is reported?


### PR DESCRIPTION
Headings add an anchor for free, letting people link to and refer directly to the ckecklist.